### PR TITLE
Add basic UI hooks and CLI skeleton

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,2 +1,76 @@
-// CLI layer - command line interface
+#!/usr/bin/env bun
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { createServices } from '@application';
+import type { Services, InfrastructureDeps } from '@application';
+import type { Project } from '@domain';
+
+const stubDeps: InfrastructureDeps = {
+  processSpawner: {
+    async spawn() {
+      return { pid: 0 };
+    },
+    async kill() {},
+  },
+  portDetector: {
+    async findFree() {
+      return 0;
+    },
+  },
+  jsonStore: {
+    async read() {
+      return null;
+    },
+    async write() {},
+  },
+  heartbeat: {
+    async tcp() {
+      return true;
+    },
+    async http() {
+      return true;
+    },
+  },
+  logger: console,
+};
+
 export const VERSION = '2.0.0';
+
+export async function runCli(argv: string[], services: Services) {
+  return yargs(argv)
+    .command(
+      'start <key>',
+      'Start project',
+      (y) => y.positional('key', { type: 'string' }),
+      async (_args) => {
+        await services.runner.start({} as Project);
+      }
+    )
+    .command(
+      'stop <key>',
+      'Stop project',
+      (y) => y.positional('key', { type: 'string' }),
+      async (args) => {
+        await services.runner.kill(args.key as string);
+      }
+    )
+    .command(
+      'restart <key>',
+      'Restart project',
+      (y) => y.positional('key', { type: 'string' }),
+      async (_args) => {
+        await services.runner.restart({} as Project);
+      }
+    )
+    .command('list', 'List projects', async () => {
+      await services.project.list();
+    })
+    .demandCommand(1)
+    .help()
+    .parse();
+}
+
+if (import.meta.main) {
+  const services = createServices(stubDeps);
+  void runCli(hideBin(process.argv), services);
+}

--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'bun:test';
-import { VERSION } from '../src/index';
+import { VERSION, runCli } from '../src/index';
 
 describe('cli package', () => {
   it('should export VERSION', () => {
     expect(VERSION).toBe('2.0.0');
   });
 
-  it('should pass stub test', () => {
-    expect(true).toBe(true);
+  it('should export runCli', () => {
+    expect(typeof runCli).toBe('function');
   });
 });

--- a/packages/cli/test/runCli.test.ts
+++ b/packages/cli/test/runCli.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'bun:test';
+import { runCli } from '../src/index';
+import type { Services } from '@application';
+
+function createServices(): Services {
+  return {
+    project: {
+      list: async () => ({ ok: true, value: [] }),
+      add: async () => ({ ok: true, value: {} as never }),
+      remove: async () => ({ ok: true, value: undefined }),
+      update: async () => ({ ok: true, value: {} as never }),
+    },
+    runner: {
+      start: async () => ({ ok: true, value: 0 }),
+      kill: async () => ({ ok: true, value: undefined }),
+      restart: async () => ({ ok: true, value: 0 }),
+      status: async () => ({ ok: true, value: 'running' as const }),
+    },
+    workspace: {
+      load: async () => ({ ok: true, value: { entries: [] } as never }),
+      save: async () => ({ ok: true, value: undefined }),
+      addEntry: async () => ({ ok: true, value: { entries: [] } as never }),
+      removeEntry: async () => ({ ok: true, value: { entries: [] } as never }),
+    },
+    log: {
+      tail: async () => ({ ok: true, value: [] }),
+      openInTerminal: async () => ({ ok: true, value: undefined }),
+    },
+    heartbeat: {
+      getStatus: async () => ({ ok: true, value: 'healthy' as const }),
+    },
+  };
+}
+
+describe('runCli', () => {
+  it('handles list command', async () => {
+    const services = createServices();
+    await runCli(['list'], services);
+    expect(true).toBe(true);
+  });
+});

--- a/packages/ui-react/src/components/AddProjectWizard.tsx
+++ b/packages/ui-react/src/components/AddProjectWizard.tsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import { DirectoryPicker } from './DirectoryPicker';
+
+export interface AddProjectWizardProps {
+  onAdd(path: string): void;
+}
+
+export function AddProjectWizard({ onAdd }: AddProjectWizardProps) {
+  const [dir, setDir] = useState('');
+
+  return (
+    <div className="add-project-wizard">
+      <DirectoryPicker onPick={setDir} />
+      <button disabled={!dir} onClick={() => onAdd(dir)}>
+        Add
+      </button>
+    </div>
+  );
+}

--- a/packages/ui-react/src/components/DirectoryPicker.tsx
+++ b/packages/ui-react/src/components/DirectoryPicker.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export interface DirectoryPickerProps {
+  onPick(path: string): void;
+}
+
+export function DirectoryPicker({ onPick }: DirectoryPickerProps) {
+  return (
+    <input
+      type="file"
+      webkitdirectory=""
+      onChange={(e) => {
+        const files = (e.target as HTMLInputElement).files;
+        if (files && files.length > 0) {
+          const dir = files[0].webkitRelativePath.split('/')[0];
+          onPick('/' + dir);
+        }
+      }}
+    />
+  );
+}

--- a/packages/ui-react/src/components/ProjectCard.tsx
+++ b/packages/ui-react/src/components/ProjectCard.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import type { Project } from '@domain';
+import type { HeartbeatStatus, LogEntry } from '@application';
+
+export interface ProjectCardProps {
+  project: Project;
+  status: HeartbeatStatus;
+  logs: LogEntry[];
+  onStart(): void;
+  onStop(): void;
+  onOpenLog?(): void;
+}
+
+export function ProjectCard({
+  project,
+  status,
+  logs,
+  onStart,
+  onStop,
+  onOpenLog,
+}: ProjectCardProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="project-card">
+      <div className="header">
+        <span>{project.name ?? project.cmd}</span>
+        <span data-testid="status-dot" className={`status-${status}`}></span>
+        <button onClick={onStart}>start</button>
+        <button onClick={onStop}>stop</button>
+        <button onClick={() => setOpen((o) => !o)}>logs</button>
+      </div>
+      {open && (
+        <div className="log-drawer">
+          {logs.map((l, idx) => (
+            <pre key={idx}>{l.message}</pre>
+          ))}
+          {onOpenLog && <button onClick={onOpenLog}>Open full log</button>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui-react/src/hooks/useRunner.ts
+++ b/packages/ui-react/src/hooks/useRunner.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Services } from '@application';
+import type { Project, Workspace } from '@domain';
+
+export interface RunnerHook {
+  workspace: Workspace | null;
+  loading: boolean;
+  reload(): Promise<void>;
+  start(project: Project): Promise<unknown>;
+  stop(projectKey: string): Promise<unknown>;
+  restart(project: Project): Promise<unknown>;
+}
+
+export function useRunner(services: Services): RunnerHook {
+  const [workspace, setWorkspace] = useState<Workspace | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const result = await services.workspace.load();
+    if (result.ok) {
+      setWorkspace(result.value);
+    }
+    setLoading(false);
+  }, [services]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return {
+    workspace,
+    loading,
+    reload: load,
+    start: (p) => services.runner.start(p),
+    stop: (k) => services.runner.kill(k),
+    restart: (p) => services.runner.restart(p),
+  };
+}

--- a/packages/ui-react/src/index.ts
+++ b/packages/ui-react/src/index.ts
@@ -1,2 +1,7 @@
 // UI React layer - thin React components
 export const VERSION = '2.0.0';
+
+export { useRunner } from './hooks/useRunner';
+export { ProjectCard } from './components/ProjectCard';
+export { DirectoryPicker } from './components/DirectoryPicker';
+export { AddProjectWizard } from './components/AddProjectWizard';

--- a/packages/ui-react/test/index.test.ts
+++ b/packages/ui-react/test/index.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'bun:test';
-import { VERSION } from '../src/index';
+import { VERSION, useRunner } from '../src/index';
 
 describe('ui-react package', () => {
   it('should export VERSION', () => {
     expect(VERSION).toBe('2.0.0');
   });
 
-  it('should pass stub test', () => {
-    expect(true).toBe(true);
+  it('should export useRunner hook', () => {
+    expect(typeof useRunner).toBe('function');
   });
 });


### PR DESCRIPTION
## Summary
- implement `useRunner` React hook
- add basic `ProjectCard`, `DirectoryPicker`, and `AddProjectWizard` components
- expand UI barrel exports
- implement a stub CLI with yargs and export `runCli`
- add minimal tests for new exports

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68682f3448488326ac207ceb2a63ba40